### PR TITLE
Change to check if UnidentifiedData have same origin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ Docs/_site/
 Docs/log.txt
 Docs/api/*.yml
 Docs/api/.manifest
+.idea/

--- a/ChartTools/Metadata/Metadata.cs
+++ b/ChartTools/Metadata/Metadata.cs
@@ -180,7 +180,8 @@ public class Metadata
     /// Unrecognized metadata
     /// </summary>
     /// <remarks>When writing, these will only be written if the target format matches the origin</remarks>
-    public HashSet<UnidentifiedMetadata> UnidentifiedData { get; } = new(new FuncEqualityComparer<UnidentifiedMetadata>((a, b) => a.Key == b.Key));
+    public HashSet<UnidentifiedMetadata> UnidentifiedData { get; } = 
+        new(new FuncEqualityComparer<UnidentifiedMetadata>((a, b) => a.Key == b.Key && a.Origin == b.Origin));
     #endregion
 
     public void ReadFile(string path) => Read(path, this);


### PR DESCRIPTION
I added an extra requirement to the FuncEqualityComparer in the MetaData class to check if Origin of two UnidentifiedMetaData be the same. (Aside from the key as well)